### PR TITLE
Update Service.php

### DIFF
--- a/src/Providers/Service.php
+++ b/src/Providers/Service.php
@@ -60,6 +60,7 @@ class Service extends ServiceProvider
             && (php_sapi_name() === 'fpm-fcgi'
                 || php_sapi_name() === 'cgi-fcgi'
                 || php_sapi_name() === 'apache2handler'
+                || php_sapi_name() === 'cli-server'
                 || config("app.env") === 'internaltesting'));
     }
 


### PR DESCRIPTION
When running an application with ```php artisan serve``` the global middleware does not run unless it includes checking the server name (php_sapi_name()) which in this case is "cli-server".
Without this check, the alternative is to manually enable and add the middleware to routes and / or route groups.